### PR TITLE
dep. update 08/13/25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,13 +14,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.15.tgz",
-      "integrity": "sha512-oaeTSbCef7U/z7rDeJA138xpG3NuKc64/rZ2qmUFkFJmnMsAPaluIifqyWd8hSSMxyP9oie3dLAqYPblag9KgA==",
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.10.0"
       }
     },
     "node_modules/typescript": {
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "dev": true,
       "license": "MIT"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^24.0.15",
-        "typescript": "^5.8.3"
+        "@types/node": "^24.2.1",
+        "typescript": "^5.9.2"
       }
     },
     "node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "LICENSE"
   ],
   "devDependencies": {
-    "@types/node": "^24.0.15",
-    "typescript": "^5.8.3"
+    "@types/node": "^24.2.1",
+    "typescript": "^5.9.2"
   },
   "scripts": {
     "build": "tsc"


### PR DESCRIPTION
> [!NOTE]
>This PR has been created with the [combine-prs](https://github.com/mdelapenya/gh-combine-prs) `gh` extension:

>gh combine-prs --query author:app/dependabot.

It combines the following PRs:

- Bump @types/node from 24.0.15 to 24.2.1 (#7) @app/dependabot
- Bump typescript from 5.8.3 to 5.9.2 (#5) @app/dependabot

## Related Issues:

- Closes #7
- Closes #5
